### PR TITLE
affichage non sollicite du message d'aide

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -93,13 +93,13 @@ int main(int argc, char **argv)
 
 	QTextCodec::setCodecForTr(QTextCodec::codecForName("UTF-8"));
 
-	QxtCommandOptions options;
+	QxtCommandOptions preOptions;
 
-	options.add("portable", QObject::tr("starts in portable mode, storing the settings in the executable folder"));
-	options.alias("portable", "p");
-	options.parse(QCoreApplication::arguments());
+	preOptions.add("portable", QObject::tr("starts in portable mode, storing the settings in the executable folder"));
+	preOptions.alias("portable", "p");
+	preOptions.parse(QCoreApplication::arguments());
 
-	if(options.count("portable") > 0)
+	if(preOptions.count("portable") > 0)
 	{
 		QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, QApplication::applicationDirPath() + "/userSettings");
 		QSettings::setPath(QSettings::IniFormat, QSettings::SystemScope, QApplication::applicationDirPath() + "/systemSettings");
@@ -169,6 +169,8 @@ int main(int argc, char **argv)
 #endif
 	}
 	app.installTranslator(&guiTranslator);
+
+	QxtCommandOptions options;
 
 	options.setFlagStyle(QxtCommandOptions::DoubleDash);
 	options.setScreenWidth(0);


### PR DESCRIPTION
je te pousse une correction. (pour un bug pouvant etre génant : impossibilité d'appeler actionaz avec des paramètres en ligne de commande autre que portable)

En effet en voulant contourner le problème de traduction du 'usage message', un bug est apparu. Un appel correct d'Actionaz avec au moins un paramètre autre que "portable", le programme affiche le message d'aide (correctement traduit !) mais cela bloque l’exécution normale d'Actionaz.

Cela est du que maintenant avec l'objet "options" on effectue deux appels à "parse". Cet appel modifie l'état de l'objet. Ce qui fait qu'au deuxième "parse", nous rencontrons ce bug.

deux solutions
- remettre l'objet options dans un état initial (mais je ne vois pas comment faire)
- utiliser deux objets (j'ai appelé le nouvel objet preOptions).
  le premier (preOptions) permet de détecter précocement l'usage du paramètre "portable"
  le second (options) gérera l'affichage conditionnelle du message d'aide
