### PR TITLE
Add missing QDataStream for Qt5.5 compiling

### DIFF
--- a/actiontools/actionexception.h
+++ b/actiontools/actionexception.h
@@ -23,6 +23,7 @@
 
 #include "actiontools_global.h"
 
+#include <QDataStream>
 #include <QMetaType>
 #include <QString>
 

--- a/actiontools/parameter.h
+++ b/actiontools/parameter.h
@@ -24,6 +24,7 @@
 #include "subparameter.h"
 #include "actiontools_global.h"
 
+#include <QDataStream>
 #include <QSharedData>
 
 namespace ActionTools

--- a/actiontools/qtsingleapplication/qtlocalpeer.h
+++ b/actiontools/qtsingleapplication/qtlocalpeer.h
@@ -48,6 +48,7 @@
 #include <QtNetwork/QLocalServer>
 #include <QtNetwork/QLocalSocket>
 #include <QtCore/QDir>
+#include <QDataStream>
 
 namespace QtLP_Private {
 #include "qtlockedfile.h"

--- a/actiontools/subparameter.h
+++ b/actiontools/subparameter.h
@@ -23,6 +23,7 @@
 
 #include "actiontools_global.h"
 
+#include <QDataStream>
 #include <QSharedData>
 #include <QVariant>
 

--- a/tools/version.h
+++ b/tools/version.h
@@ -24,6 +24,7 @@
 #include "tools_global.h"
 
 #include <QString>
+#include <QDataStream>
 #include <QDebug>
 #include <QSharedData>
 #include <QMetaType>


### PR DESCRIPTION
This will fix errors like:

```
version.cpp: In function 'QDataStream& operator<<(QDataStream&, const Tools::Version&)':
version.cpp:339:4: error: ambiguous overload for 'operator<<' (operand types are 'QDataStream' and 'int')```