### PR TITLE
Fix build failure with Qt 6.10 (Missing Qt6::QmlPrivate)

### DIFF
--- a/actiontools/CMakeLists.txt
+++ b/actiontools/CMakeLists.txt
@@ -294,6 +294,7 @@ setup_target(${PROJECT})
 
 find_package(OpenCV REQUIRED core imgproc)
 find_package(Qt6 ${ACT_MINIMUM_QT_VERSION} COMPONENTS Widgets Qml REQUIRED)
+find_package(Qt6 COMPONENTS QmlPrivate REQUIRED)
 
 set(EXTRA_CXX_FLAGS "")
 if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
Hello,

On recent rolling-release distributions (like Arch Linux) that have updated to Qt 6.10, compiling Actiona currently fails with the following CMake error:

`Target "actiontools" links to: Qt6::QmlPrivate but the target was not found.`

This happens because the internal QmlPrivate module needs to be explicitly requested in the newer Qt versions. Adding the following line to `actiontools/CMakeLists.txt` resolves the issue and allows the project to build successfully again:

find_package(Qt6 COMPONENTS QmlPrivate REQUIRED)

Thanks for your work on Actiona!