### PR TITLE
Add version check for Qt6::QmlPrivate dependency

### DIFF
--- a/actiontools/CMakeLists.txt
+++ b/actiontools/CMakeLists.txt
@@ -294,7 +294,9 @@ setup_target(${PROJECT})
 
 find_package(OpenCV REQUIRED core imgproc)
 find_package(Qt6 ${ACT_MINIMUM_QT_VERSION} COMPONENTS Widgets Qml REQUIRED)
-find_package(Qt6 COMPONENTS QmlPrivate REQUIRED)
+if(Qt6_VERSION VERSION_GREATER_EQUAL "6.10.0")
+    find_package(Qt6 COMPONENTS QmlPrivate REQUIRED)
+endif()
 
 set(EXTRA_CXX_FLAGS "")
 if(CMAKE_BUILD_TYPE STREQUAL "Release")


### PR DESCRIPTION
The previous fix broke builds on older Qt versions (like 6.4.3 used in CI) where QmlPrivate is not yet a standalone component. This change adds a version check to ensure QmlPrivate is only requested for Qt 6.10.0 and newer, maintaining compatibility with older releases while fixing the build on rolling-release distributions like Arch Linux.